### PR TITLE
Enable docker containers to communicate with remote roscores

### DIFF
--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -71,7 +71,7 @@ fi
 if docker image inspect "$image_name" >/dev/null 2>&1 ; then
     echo "Image '${image_name}' exists locally"
     echo "Starting $image_name"
-    ROS_URI="${ROS_MASTER_URI:-"localhost:11311"}"
+    ROS_URI="${ROS_MASTER_URI:-"http://localhost:11311/"}"
     ROS_LOCAL_IP="${ROS_IP:-"127.0.0.1"}"
     docker run --network host --gpus all -e ROS_MASTER_URI=${ROS_URI} -e ROS_IP=${ROS_LOCAL_IP} --name $1_backend --rm -it $image_name
 else

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -71,7 +71,9 @@ fi
 if docker image inspect "$image_name" >/dev/null 2>&1 ; then
     echo "Image '${image_name}' exists locally"
     echo "Starting $image_name"
-    docker run --network host --gpus all --name $1_backend --rm -it $image_name
+    ROS_URI="${ROS_MASTER_URI:-"localhost:11311"}"
+    ROS_LOCAL_IP="${ROS_IP:-"127.0.0.1"}"
+    docker run --network host --gpus all -e ROS_MASTER_URI=${ROS_URI} -e ROS_IP=${ROS_LOCAL_IP} --name $1_backend --rm -it $image_name
 else
     echo "No valid container for backend ${image_name} can be started"
     exit 1


### PR DESCRIPTION
Docker containers need to have the ROS_MASTER_URI envvar set properly in order to be able to communicate with remove masters. This PR adds changes that create suppport for this.