### PR TITLE
Update requirements to ommit python3 versions of opencv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.13.3
-opencv-python>=3.2.0
+opencv-python>=3.2.0, <=4.2.0.32
 pathlib>=1.0.1


### PR DESCRIPTION
required for dockerising RASberry or fails during docker build and checks 