### PR TITLE
Added a MaskR-CNN interface and other small fixes

### DIFF
--- a/launch/detector.launch
+++ b/launch/detector.launch
@@ -9,11 +9,11 @@
     </group>
 -->
 
-    <arg name="image_ns" default="/camera/camera1/color"/>
-    <arg name="depth_ns" default="/camera/camera1/aligned_depth_to_color"/> <!--/camera/aligned_depth_to_color"-->
+    <arg name="image_ns" default=""/>
+    <arg name="depth_ns" default=""/>
     <arg name="score" default="0.3"/>
-    <arg name="show_vis" default="true"/>
-    <arg name="publish_source" default="true"/>
+    <arg name="show_vis" default="false"/>
+    <arg name="publish_source" default="false"/>
 
     <!-- client -->
     <node pkg="rasberry_perception" name="rasberry_perception_detector" type="detection_client.py" output="screen" respawn="true">

--- a/launch/detector.launch
+++ b/launch/detector.launch
@@ -9,12 +9,13 @@
     </group>
 -->
 
-    <arg name="image_ns" default="/camera/color"/>
-    <arg name="depth_ns" default=""/> <!--/camera/aligned_depth_to_color"-->
-    <arg name="score" default="0.5"/>
-    <arg name="show_vis" default="false"/>
-    <arg name="publish_source" default="false"/>
+    <arg name="image_ns" default="/camera/camera1/color"/>
+    <arg name="depth_ns" default="/camera/camera1/aligned_depth_to_color"/> <!--/camera/aligned_depth_to_color"-->
+    <arg name="score" default="0.3"/>
+    <arg name="show_vis" default="true"/>
+    <arg name="publish_source" default="true"/>
 
+    <!-- client -->
     <node pkg="rasberry_perception" name="rasberry_perception_detector" type="detection_client.py" output="screen" respawn="true">
         <param name="image_ns" type="str" value="$(arg image_ns)"/>
         <param name="depth_ns" type="str" value="$(arg depth_ns)"/>

--- a/scripts/run_backend.sh
+++ b/scripts/run_backend.sh
@@ -74,7 +74,7 @@ if docker image inspect "$image_name" >/dev/null 2>&1 ; then
     echo "Starting $image_name"
     ROS_URI="${ROS_MASTER_URI:-"http://localhost:11311/"}"
     ROS_LOCAL_IP="${ROS_IP:-"127.0.0.1"}"
-    docker run --network host --gpus all -e ROS_MASTER_URI=${ROS_URI} -e ROS_IP=${ROS_LOCAL_IP} --name $1_backend --rm -it $image_name
+    docker run --network host -e ROS_MASTER_URI=${ROS_URI} -e ROS_IP=${ROS_LOCAL_IP} --name $1_backend --rm -it $image_name
 else
     echo "No valid container for backend ${image_name} can be started"
     exit 1

--- a/src/rasberry_perception/detection_client.py
+++ b/src/rasberry_perception/detection_client.py
@@ -30,7 +30,7 @@ class RunClientOnTopic:
         # Initialise class members
         self.score_thresh = score_thresh
         self._service_name = service_name
-        self.namespace = "rasberry_perception/"
+        self.namespace = rospy.get_name() + "/" #"rasberry_perception/"
         self.depth_enabled = bool(depth_namespace)
         self.visualisation_enabled = visualisation_enabled
         self.publish_source = publish_source

--- a/src/rasberry_perception/detection_server.py
+++ b/src/rasberry_perception/detection_server.py
@@ -19,8 +19,7 @@ def _default_arg_parser(args=None):
 
     # if the server node is launched from using roslaunch
     # these args are prepended. So remove them beforehand.
-    unknown = [arg for arg in unknown if "__name:=" not in arg ]
-    unknown = [arg for arg in unknown if "__log:=" not in arg ]
+    unknown = [arg for arg in unknown if "__name:=" not in arg or "__log:=" not in arg]
     
     # Add unrecognised args as kwargs for passing the detection server
     unknown_parser = argparse.ArgumentParser()

--- a/src/rasberry_perception/detection_server.py
+++ b/src/rasberry_perception/detection_server.py
@@ -17,11 +17,18 @@ def _default_arg_parser(args=None):
     parser.add_argument('--backend', type=str, help="Which backend to use.", default=None)
     parsed_args, unknown = parser.parse_known_args() #this is an 'internal' method
 
+    # if the server node is launched from using roslaunch
+    # these args are prepended. So remove them beforehand.
+    unknown = [arg for arg in unknown if "__name:=" not in arg ]
+    unknown = [arg for arg in unknown if "__log:=" not in arg ]
+ 
     # Add unrecognised args as kwargs for passing the detection server
     unknown_parser = argparse.ArgumentParser()
+
     for arg in unknown:
         if arg.startswith(("-", "--")):
             unknown_parser.add_argument(arg, type=str)
+
     unknown_args = unknown_parser.parse_args(unknown)
     unknown_kwargs = {a: getattr(unknown_args, a) for a in vars(unknown_args)} if len(vars(unknown_args)) else None
 

--- a/src/rasberry_perception/detection_server.py
+++ b/src/rasberry_perception/detection_server.py
@@ -21,7 +21,7 @@ def _default_arg_parser(args=None):
     # these args are prepended. So remove them beforehand.
     unknown = [arg for arg in unknown if "__name:=" not in arg ]
     unknown = [arg for arg in unknown if "__log:=" not in arg ]
- 
+    
     # Add unrecognised args as kwargs for passing the detection server
     unknown_parser = argparse.ArgumentParser()
 
@@ -41,6 +41,7 @@ def __detection_server_runner():
 
     service_name = default_service_name
     _node_name = service_name + "_server"
+    
     rospy.init_node(_node_name)
 
     server = Server(backend=args.backend, backend_kwargs=args_kwargs, service_name=service_name)

--- a/src/rasberry_perception/interfaces/__init__.py
+++ b/src/rasberry_perception/interfaces/__init__.py
@@ -8,4 +8,6 @@ from .detectron2 import Detectron2Server
 from .gazebo_berries import GazeboRenderedBerriesServer
 from .fruitcast import FruitCastServer
 
-__all__ = ["FruitCastServer", "GazeboRenderedBerriesServer", "Detectron2Server", "DefaultDetectionServer"]
+from .scene_analyzer_server import SceneAnalyzerServer
+
+__all__ = ["FruitCastServer", "GazeboRenderedBerriesServer", "Detectron2Server", "DefaultDetectionServer", "SceneAnalyzerServer"]

--- a/src/rasberry_perception/interfaces/scene_analyzer_server.py
+++ b/src/rasberry_perception/interfaces/scene_analyzer_server.py
@@ -1,3 +1,6 @@
+# Muhammad Arshad Khan
+# Date: 22-June-2022
+
 import ros_numpy
 
 from rasberry_perception.interfaces.registry import DETECTION_REGISTRY
@@ -13,17 +16,17 @@ from sensor_msgs.msg import Image
 #general imports
 import os, sys, numpy as np, pickle, logging
 import pickle            
-# detectron imports
-from detectron2.config           import get_cfg
-from detectron2.engine.defaults  import DefaultPredictor
-from detectron2                  import model_zoo
-from detectron2.utils.visualizer import Visualizer
-from detectron2.data             import MetadataCatalog, DatasetCatalog
-import cv2
 
-@DETECTION_REGISTRY.register_detection_backend("scene_analyzer_server")  # (1)
-class SceneAnalyzerServer(BaseDetectionServer):  # (2)
-    # These args are passed from ros parameters when running the backend
+# detectron imports
+from detectron2.config import get_cfg
+from detectron2.engine.defaults  import DefaultPredictor
+from detectron2 import model_zoo
+from detectron2.utils.visualizer import Visualizer
+
+
+@DETECTION_REGISTRY.register_detection_backend("scene_analyzer_server")   
+class SceneAnalyzerServer(BaseDetectionServer):  
+
     def __init__(self, model_path, metadata_path, cfg_path ): 
 
         # initialize mask predictor
@@ -40,8 +43,6 @@ class SceneAnalyzerServer(BaseDetectionServer):  # (2)
         elif not os.path.exists( metadata_path ) : 
             raise ("'metadata_path' does not exists" )
         else: 
-            # Do initialisation code here
-            # self.scene/_analyser_predictor = DetectronCocoObjectDetection( )
             self.scene_analyser_predictor = MasksPredictor( model_path, cfg_path, metadata_path )
 
         self.busy = False 
@@ -52,37 +53,35 @@ class SceneAnalyzerServer(BaseDetectionServer):  # (2)
     def get_detector_results(self, request):  # (3)
         if self.busy:  # Example of other status responses
             return GetDetectorResultsResponse(status=ServiceStatus(BUSY=True))
-        
-        # if self.scene_analyser_predictor == None: 
-        #     return GetDetectorResultsResponse(status=ServiceStatus(ERROR=True))
-        
+                
         # Populate a detections message
         detections = Detections()
-
-        rospy.loginfo("Processing the request from client here..")
         detections = self.scene_analyser_predictor.get_predictions( request.image )
-        # i.e. detections = image_to_results_function(image=ros_numpy.numpify(request.image))
-        return GetDetectorResultsResponse(status=ServiceStatus(OKAY=True), results=detections)
 
+        return GetDetectorResultsResponse(status=ServiceStatus(OKAY=True), results=detections)
     
 
-"""
-Repurposed from scene_analyser from FastPick
-"""
+
 
 class MasksPredictor:
+    """
+    General MaskRCNN model class. 
+    """
+    def __init__(self, model_file, config_file, metadata_file, num_classes  = 1):
+        """ A rather simple wrapper around mask-rcnn model using detectron2 library
+            for inference.
 
-    def __init__(self, model_file, config_file, metadata_file, num_classes  = 3 , accuracy = 0.01):
-        
-        self.counter = 1
-        self.accuracy = accuracy 
-        self.scale=1.0
+        Args: 
+            - mode_file (str): absolute path to maskrcnn .pth file. 
+            - metadata_file (str): absolute path to maskrcnn meta data file that stores classes name etc.
+            - config_file (str): detectron2 config used during model training. 
+        Kwargs:
+            - num_classes (int): 
+        """
 
         self.metadata=self.get_metadata(metadata_file)
         self.cfg = self.init_config(model_file, config_file, num_classes)
 
-        print ( self.metadata)
-        print ( self.cfg.DATASETS.TRAIN[0] )
         try:
             self.predictor=DefaultPredictor(self.cfg)
         except Exception as e:
@@ -99,14 +98,12 @@ class MasksPredictor:
             print(e)
             raise Exception(e)
 
-        cfg.MODEL.WEIGHTS = model_file #os.path.join(model_file)
-        cfg.MODEL.ROI_HEADS.NUM_CLASSES = num_classes  # 1.strawberry, 2. Canopy, 3. Rigid Structure
+        cfg.MODEL.WEIGHTS = model_file  
+        cfg.MODEL.ROI_HEADS.NUM_CLASSES = num_classes   
         return cfg
 
-    def get_metadata(self,metadata_file):
+    def get_metadata(self, metadata_file):
 
-        #metadata file has name of classes, it is created to avoid having custom dataset and taking definitions
-        # from annotations, instead. It has structure of MetaDataCatlog output of detectron2
         try:
             file = open(metadata_file, 'rb')
         except Exception as e:
@@ -120,52 +117,40 @@ class MasksPredictor:
 
     def get_predictions(self, ros_rgb_image ):
         
-
+        # get the inference from model
         np_rgb_image = ros_numpy.numpify( ros_rgb_image )
         outputs = self.predictor( np_rgb_image )
 
+        # though not absolutely neccessary, but we can use 
+        # detectron2 visualizer to draw the inference. 
         v = Visualizer(np_rgb_image[:, :, ::-1], self.metadata , scale=1.0)
         out = v.draw_instance_predictions(outputs["instances"].to("cpu"))
 
+        # get the inference in as numpy arrays
         pred_classes = outputs["instances"].get_fields()["pred_classes"].to("cpu").numpy()
         scores = outputs["instances"].get_fields()["scores"].to("cpu").numpy()
         pred_masks = outputs["instances"].get_fields()["pred_masks"].to("cpu").numpy()
         pred_boxes = outputs["instances"].get_fields()["pred_boxes"].to("cpu").tensor.numpy()
 
-        
-        prediction_output = {
-            "pred_classes" : pred_classes,
-            "scores" : scores,
-            "pred_masks" : pred_masks,
-            "pred_boxes" : pred_boxes,
-        }            
- 
-
-        output_image = out.get_image()[:, :, ::-1].astype(np.uint8)
-        output_filepath = "/home/arshad/Desktop/outputs/output_{}.png".format( self.counter )
-        cv2.imwrite( output_filepath , np.concatenate( (cv2.cvtColor(np_rgb_image, cv2.COLOR_RGB2BGR), cv2.cvtColor(output_image.copy(), cv2.COLOR_RGB2BGR) ), axis=0 ) ) 
-        self.counter += 1
-
+        # fill the ROS detection message 
+        # for service client.
         detections = Detections()
         detections.camera_frame = ros_numpy.msgify( Image, output_image, encoding=ros_rgb_image.encoding)
 
         for detected_object, score in enumerate(scores): 
-            
-            if (score > self.accuracy and pred_classes[detected_object] == 0 ):
 
-                detection = Detection()
-                
-                roi = RegionOfInterest()
-                soi = SegmentOfInterest()
-                roi.x1, roi.y1, roi.x2, roi.y2 = pred_boxes[detected_object]
+            detection = Detection()            
+            roi = RegionOfInterest()
+            soi = SegmentOfInterest()
+            roi.x1, roi.y1, roi.x2, roi.y2 = pred_boxes[detected_object]
 
-                mask = np.where( pred_masks[detected_object]  )
-                soi.x , soi.y = list( mask[1] ) , list( mask[0] ) 
-            
-                detection.roi = roi
-                detection.seg_roi = soi
-                detection.class_name = "Strawberry"
-                detection.confidence = score
-                detections.objects.append( detection )
+            mask = np.where( pred_masks[detected_object]  )
+            soi.x , soi.y = list( mask[1] ) , list( mask[0] ) 
+        
+            detection.roi = roi
+            detection.seg_roi = soi
+            detection.class_name = "Strawberry"
+            detection.confidence = score
+            detections.objects.append( detection )
 
         return detections

--- a/src/rasberry_perception/interfaces/scene_analyzer_server.py
+++ b/src/rasberry_perception/interfaces/scene_analyzer_server.py
@@ -24,8 +24,7 @@ import cv2
 @DETECTION_REGISTRY.register_detection_backend("scene_analyzer_server")  # (1)
 class SceneAnalyzerServer(BaseDetectionServer):  # (2)
     # These args are passed from ros parameters when running the backend
-    def __init__(self, model_path="/home/arshad/robot_highway/data_ws/src/raspberry_fruit_mapping/berry_tracker/models/fp_model.pth", metadata_path="/home/arshad/robot_highway/data_ws/src/raspberry_fruit_mapping/berry_tracker/models/metadata.pkl", cfg_path="COCO-InstanceSegmentation/mask_rcnn_R_101_FPN_3x.yaml" ): 
-
+    def __init__(self, model_path, metadata_path, cfg_path ): 
 
         # initialize mask predictor
         self.busy = True
@@ -133,6 +132,7 @@ class MasksPredictor:
         pred_masks = outputs["instances"].get_fields()["pred_masks"].to("cpu").numpy()
         pred_boxes = outputs["instances"].get_fields()["pred_boxes"].to("cpu").tensor.numpy()
 
+        
         prediction_output = {
             "pred_classes" : pred_classes,
             "scores" : scores,

--- a/src/rasberry_perception/interfaces/scene_analyzer_server.py
+++ b/src/rasberry_perception/interfaces/scene_analyzer_server.py
@@ -1,0 +1,171 @@
+import ros_numpy
+
+from rasberry_perception.interfaces.registry import DETECTION_REGISTRY
+from rasberry_perception.interfaces.default import BaseDetectionServer
+from rasberry_perception.msg import Detections, ServiceStatus, Detection, RegionOfInterest, SegmentOfInterest
+from rasberry_perception.srv import GetDetectorResultsRequest, GetDetectorResultsResponse
+
+import time 
+import rospy
+import os
+from sensor_msgs.msg import Image
+
+#general imports
+import os, sys, numpy as np, pickle, logging
+import pickle            
+# detectron imports
+from detectron2.config           import get_cfg
+from detectron2.engine.defaults  import DefaultPredictor
+from detectron2                  import model_zoo
+from detectron2.utils.visualizer import Visualizer
+from detectron2.data             import MetadataCatalog, DatasetCatalog
+import cv2
+
+@DETECTION_REGISTRY.register_detection_backend("scene_analyzer_server")  # (1)
+class SceneAnalyzerServer(BaseDetectionServer):  # (2)
+    # These args are passed from ros parameters when running the backend
+    def __init__(self, model_path="/home/arshad/robot_highway/data_ws/src/raspberry_fruit_mapping/berry_tracker/models/fp_model.pth", metadata_path="/home/arshad/robot_highway/data_ws/src/raspberry_fruit_mapping/berry_tracker/models/metadata.pkl", cfg_path="COCO-InstanceSegmentation/mask_rcnn_R_101_FPN_3x.yaml" ): 
+
+
+        # initialize mask predictor
+        self.busy = True
+        self.scene_analyser_predictor = None
+        if model_path == "" : 
+            raise ("Please provide scene analyser model file absolute path") 
+        elif metadata_path == "" : 
+            raise ("Please proide scene analyser meta file absolute path")
+        elif cfg_path == "": 
+            raise ("Please proide scene analyser config name")
+        elif not os.path.exists( model_path ): 
+            raise ("'model_path' does not exists" )
+        elif not os.path.exists( metadata_path ) : 
+            raise ("'metadata_path' does not exists" )
+        else: 
+            # Do initialisation code here
+            # self.scene/_analyser_predictor = DetectronCocoObjectDetection( )
+            self.scene_analyser_predictor = MasksPredictor( model_path, cfg_path, metadata_path )
+
+        self.busy = False 
+        rospy.loginfo("Initializing the scene analyzer server...")
+        time.sleep(1)
+        BaseDetectionServer.__init__(self)  # Spins the server and waits for requests!
+
+    def get_detector_results(self, request):  # (3)
+        if self.busy:  # Example of other status responses
+            return GetDetectorResultsResponse(status=ServiceStatus(BUSY=True))
+        
+        # if self.scene_analyser_predictor == None: 
+        #     return GetDetectorResultsResponse(status=ServiceStatus(ERROR=True))
+        
+        # Populate a detections message
+        detections = Detections()
+
+        rospy.loginfo("Processing the request from client here..")
+        detections = self.scene_analyser_predictor.get_predictions( request.image )
+        # i.e. detections = image_to_results_function(image=ros_numpy.numpify(request.image))
+        return GetDetectorResultsResponse(status=ServiceStatus(OKAY=True), results=detections)
+
+    
+
+"""
+Repurposed from scene_analyser from FastPick
+"""
+
+class MasksPredictor:
+
+    def __init__(self, model_file, config_file, metadata_file, num_classes  = 3 , accuracy = 0.1):
+        
+        self.counter = 1
+        self.accuracy = accuracy 
+        self.scale=1.0
+
+        self.metadata=self.get_metadata(metadata_file)
+        self.cfg = self.init_config(model_file, config_file, num_classes)
+
+        print ( self.metadata)
+        print ( self.cfg.DATASETS.TRAIN[0] )
+        try:
+            self.predictor=DefaultPredictor(self.cfg)
+        except Exception as e:
+            logging.error(e)
+            print(e)
+            raise Exception(e)
+
+    def init_config(self, model_file, config_file, num_classes):
+        cfg = get_cfg()
+        try:
+            cfg.merge_from_file(model_zoo.get_config_file(config_file))
+        except Exception as e:
+            logging.error(e)
+            print(e)
+            raise Exception(e)
+
+        cfg.MODEL.WEIGHTS = model_file #os.path.join(model_file)
+        cfg.MODEL.ROI_HEADS.NUM_CLASSES = num_classes  # 1.strawberry, 2. Canopy, 3. Rigid Structure
+        return cfg
+
+    def get_metadata(self,metadata_file):
+
+        #metadata file has name of classes, it is created to avoid having custom dataset and taking definitions
+        # from annotations, instead. It has structure of MetaDataCatlog output of detectron2
+        try:
+            file = open(metadata_file, 'rb')
+        except Exception as e:
+            logging.error(e)
+            print(e)
+            raise Exception(e)
+
+        data = pickle.load(file)
+        file.close()
+        return data
+
+    def get_predictions(self, ros_rgb_image ):
+        
+
+        np_rgb_image = ros_numpy.numpify( ros_rgb_image )
+        outputs = self.predictor( np_rgb_image )
+
+        v = Visualizer(np_rgb_image[:, :, ::-1], self.metadata , scale=1.0)
+        out = v.draw_instance_predictions(outputs["instances"].to("cpu"))
+
+        pred_classes = outputs["instances"].get_fields()["pred_classes"].to("cpu").numpy()
+        scores = outputs["instances"].get_fields()["scores"].to("cpu").numpy()
+        pred_masks = outputs["instances"].get_fields()["pred_masks"].to("cpu").numpy()
+        pred_boxes = outputs["instances"].get_fields()["pred_boxes"].to("cpu").tensor.numpy()
+
+        prediction_output = {
+            "pred_classes" : pred_classes,
+            "scores" : scores,
+            "pred_masks" : pred_masks,
+            "pred_boxes" : pred_boxes,
+        }            
+ 
+
+        output_image = out.get_image()[:, :, ::-1].astype(np.uint8)
+        output_filepath = "/home/arshad/Desktop/outputs/output_{}.png".format( self.counter )
+        cv2.imwrite( output_filepath , np.concatenate( (cv2.cvtColor(np_rgb_image, cv2.COLOR_RGB2BGR), cv2.cvtColor(output_image.copy(), cv2.COLOR_RGB2BGR) ), axis=0 ) ) 
+        self.counter += 1
+
+        detections = Detections()
+        detections.camera_frame = ros_numpy.msgify( Image, output_image, encoding=ros_rgb_image.encoding)
+
+        for detected_object, score in enumerate(scores): 
+            
+            if (score > self.accuracy and pred_classes[detected_object] == 0 ):
+
+                detection = Detection()
+                
+                roi = RegionOfInterest()
+                soi = SegmentOfInterest()
+                roi.x1, roi.y1, roi.x2, roi.y2 = pred_boxes[detected_object]
+
+                mask = np.where( pred_masks[detected_object]  )
+                soi.x , soi.y = list( mask[1] ) , list( mask[0] ) 
+            
+                detection.roi = roi
+                detection.seg_roi = soi
+                detection.class_name = "Strawberry"
+                detection.confidence = score
+                detections.objects.append( detection )
+
+        return detections

--- a/src/rasberry_perception/interfaces/scene_analyzer_server.py
+++ b/src/rasberry_perception/interfaces/scene_analyzer_server.py
@@ -73,7 +73,7 @@ Repurposed from scene_analyser from FastPick
 
 class MasksPredictor:
 
-    def __init__(self, model_file, config_file, metadata_file, num_classes  = 3 , accuracy = 0.1):
+    def __init__(self, model_file, config_file, metadata_file, num_classes  = 3 , accuracy = 0.01):
         
         self.counter = 1
         self.accuracy = accuracy 

--- a/src/rasberry_perception/service.py
+++ b/src/rasberry_perception/service.py
@@ -57,6 +57,7 @@ class Server:
             backend_kwargs = {}
             for arg_name in required_args:
                 p_arg = "~" + arg_name
+                rospy.logerr("Search for: {}".format( p_arg ) )
                 if rospy.has_param(p_arg):
                     assigned_parameters.append(p_arg)
                     backend_kwargs[arg_name] = rospy.get_param(p_arg)
@@ -71,8 +72,9 @@ class Server:
         # Ensure the required args exist
         _missing_args = [a for a in required_args if a not in backend_kwargs]
         if len(_missing_args) > 0:
+            _missing_args_str = ", ".join(_missing_args)
             raise rospy.ROSException("Cannot initialise without the '{}' parameter(s) for the '{}' backend".format(
-                ", ".join(_missing_args), backend
+                _missing_args_str, backend
             ))
 
         self.server_args = backend_kwargs

--- a/src/rasberry_perception/service.py
+++ b/src/rasberry_perception/service.py
@@ -57,7 +57,6 @@ class Server:
             backend_kwargs = {}
             for arg_name in required_args:
                 p_arg = "~" + arg_name
-                rospy.logerr("Search for: {}".format( p_arg ) )
                 if rospy.has_param(p_arg):
                     assigned_parameters.append(p_arg)
                     backend_kwargs[arg_name] = rospy.get_param(p_arg)


### PR DESCRIPTION
1) Added a new interface for scene analyzer locally. Considering that someone has a trained MaskRCNN model, they can replace the model path in scene_analyzer_server.py file (or pass model filepath, meta filepath using server node). 

2) Changed the namespace of the perception client from fixed 'rasberry_perception' to its node name which is helpful when multiple clients are brought up and their (vis) results are published on different namespaced topics. 

3) Removed '__name:=' and '__logs:=' from the unknown kwargs before passing the args to interface layer. This allows to launch server node using roslaunch without any errors. 